### PR TITLE
add function to move a picture around via points

### DIFF
--- a/src/LittleBlocks.Excel.ClosedXml/DataSheetPicture.cs
+++ b/src/LittleBlocks.Excel.ClosedXml/DataSheetPicture.cs
@@ -16,6 +16,7 @@
 // 
 
 using System;
+using System.Drawing; // this is refactored out in the latest version of closed xml. Big changes to make it work.
 using ClosedXML.Excel.Drawings;
 
 namespace LittleBlocks.Excel.ClosedXml
@@ -45,6 +46,14 @@ namespace LittleBlocks.Excel.ClosedXml
             if (column <= 0) throw new ArgumentOutOfRangeException(nameof(column));
 
             _picture.MoveTo(row, column);
+            return this;
+        }
+        
+        public IDataSheetPicture MoveTo(IDataSheetCell cell, Point offset)
+        {
+            if (cell == null) throw new ArgumentNullException(nameof(cell));
+            var internalCell = ((DataSheetCell)cell).Internal;
+            _picture.MoveTo(internalCell, offset);
             return this;
         }
 

--- a/src/LittleBlocks.Excel/IDataSheetPicture.cs
+++ b/src/LittleBlocks.Excel/IDataSheetPicture.cs
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // 
 
+using System.Drawing;
+
 namespace LittleBlocks.Excel
 {
     public interface IDataSheetPicture
@@ -24,5 +26,6 @@ namespace LittleBlocks.Excel
         IDataSheetPicture Scale(double scaleValue);
         IDataSheetPicture WithSize(int width, int height);
         IDataSheetPicture WithPlacement(PicturePlacement placement);
+        IDataSheetPicture MoveTo(IDataSheetCell cell, Point offset);
     }
 }


### PR DESCRIPTION
This PR contains only one change to allow me to move logos around within the worksheet.

I need this to stop the logos overlapping the borders in some cases.

Also - there is a new version of closed xml with many major changes. We should look to move to this in the future although its quite a big piece of work