### PR TITLE
bump the git version

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,9 +1,9 @@
-next-version: 1.0.2
+next-version: 1.0.3
 mode: Mainline
 major-version-bump-message: '\+semver:\s?(breaking|major)'
 minor-version-bump-message: '\+semver:\s?(feature|minor)'
 patch-version-bump-message: '\+semver:\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
 ignore:
-  commits-before: 2023-01-01T00:00:00
+  commits-before: 2023-01-01T00:00:00 # what is this for? should it be removed?
 


### PR DESCRIPTION
The git version wasnt auto updated on merge - I've manually done this now. 

I'm unfamiliar with the parameters required for git version - but I dont see the purpose of ignoring commits before a certain date? unless that gets updated automatically it seems a weird one. 

Let me know if I should remove this before merge or if it should be updated in a different way.

* The last build was successful technically but it didnt push a fresh version  
![image](https://user-images.githubusercontent.com/33624714/215319329-fcb93294-403e-434a-8ba9-42715db30fc4.png)


... thinking about it - it would be good if the ignore commit field was updated automatically by the last merged commit hash to main 