### PR TITLE
Dotnet8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "3.1.x"
+          dotnet-version: "8.0.x"
       - name: Install dependencies
         run: dotnet restore src
       - name: Use GitVersion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.7
         with:
-          versionSpec: "5.5.x"
+          versionSpec: "5.8.x"
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: "8.0.x"
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: "3.1.x"
+          dotnet-version: "8.0.x"
       - name: Install dependencies
         run: dotnet restore src
       - name: Use GitVersion

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v0.9.7
         with:
-          versionSpec: "5.5.x"
+          versionSpec: "5.8.x"
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: "8.0.x"
       - name: Install dependencies

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,9 +1,7 @@
-next-version: 1.0.3
+next-version: 2.0.0
 mode: Mainline
 major-version-bump-message: '\+semver:\s?(breaking|major)'
 minor-version-bump-message: '\+semver:\s?(feature|minor)'
 patch-version-bump-message: '\+semver:\s?(fix|patch)'
 no-bump-message: '\+semver:\s?(none|skip)'
-ignore:
-  commits-before: 2023-01-01T00:00:00 # what is this for? should it be removed?
 

--- a/src/LittleBlocks.Excel.ClosedXml.IntegrationTests/Helpers/DatafileFixture.cs
+++ b/src/LittleBlocks.Excel.ClosedXml.IntegrationTests/Helpers/DatafileFixture.cs
@@ -37,7 +37,7 @@ namespace LittleBlocks.Excel.ClosedXml.IntegrationTests.Helpers
         private IWorkbook LoadWorkbook(string dataFile)
         {
             var datafilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Data", dataFile);
-            var workbook = new XLWorkbook(GetMemoryStream(datafilePath), XLEventTracking.Disabled);
+            var workbook = new XLWorkbook(GetMemoryStream(datafilePath));
             var fileName = Path.GetFileName(datafilePath);
             return new Workbook(workbook, fileName);
         }

--- a/src/LittleBlocks.Excel.ClosedXml.IntegrationTests/LittleBlocks.Excel.ClosedXml.IntegrationTests.csproj
+++ b/src/LittleBlocks.Excel.ClosedXml.IntegrationTests/LittleBlocks.Excel.ClosedXml.IntegrationTests.csproj
@@ -4,7 +4,7 @@
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="LittleBlocks.Testing" Version="1.0.1" />
+        <PackageReference Include="LittleBlocks.Testing" Version="2.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="xunit" Version="2.7.0" />

--- a/src/LittleBlocks.Excel.ClosedXml.IntegrationTests/LittleBlocks.Excel.ClosedXml.IntegrationTests.csproj
+++ b/src/LittleBlocks.Excel.ClosedXml.IntegrationTests/LittleBlocks.Excel.ClosedXml.IntegrationTests.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="LittleBlocks.Testing" Version="1.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/LittleBlocks.Excel.ClosedXml/DataSheetCell.cs
+++ b/src/LittleBlocks.Excel.ClosedXml/DataSheetCell.cs
@@ -112,7 +112,7 @@ namespace LittleBlocks.Excel.ClosedXml
         public object Value
         {
             get => _cell.Value;
-            set => _cell.Value = value;
+            set => _cell.Value = (XLCellValue)value;
         }
 
         public bool IsEmpty()

--- a/src/LittleBlocks.Excel.ClosedXml/LittleBlocks.Excel.ClosedXml.csproj
+++ b/src/LittleBlocks.Excel.ClosedXml/LittleBlocks.Excel.ClosedXml.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="ClosedXML" Version="0.102.2" />
-        <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+        <PackageReference Include="DocumentFormat.OpenXml" Version="2.20.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
         <PackageReference Include="System.Drawing.Common" Version="8.0.4" />
     </ItemGroup>

--- a/src/LittleBlocks.Excel.ClosedXml/LittleBlocks.Excel.ClosedXml.csproj
+++ b/src/LittleBlocks.Excel.ClosedXml/LittleBlocks.Excel.ClosedXml.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Mohammad Moattar, Justin French, Aurimas Gecas</Authors>
         <Company>ICG</Company>
@@ -8,10 +8,10 @@
         <RepositoryUrl>https://github.com/LittleBlocks/LittleBlocks.Excel</RepositoryUrl>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="ClosedXML" Version="0.97.0" />
-        <PackageReference Include="DocumentFormat.OpenXml" Version="2.19.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
-        <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
+        <PackageReference Include="ClosedXML" Version="0.102.2" />
+        <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+        <PackageReference Include="System.Drawing.Common" Version="8.0.4" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\LittleBlocks.Excel\LittleBlocks.Excel.csproj" />

--- a/src/LittleBlocks.Excel.ClosedXml/WorkbookLoader.cs
+++ b/src/LittleBlocks.Excel.ClosedXml/WorkbookLoader.cs
@@ -40,7 +40,7 @@ namespace LittleBlocks.Excel.ClosedXml
                 var fileName = Path.GetFileName(path);
                 var stream = FileHelper.ReadFileToMemoryStream(path);
                 
-                return new Workbook(new XLWorkbook(stream, XLEventTracking.Disabled), fileName);
+                return new Workbook(new XLWorkbook(stream), fileName);
             }
             catch (FileFormatException ex)
             {
@@ -54,7 +54,7 @@ namespace LittleBlocks.Excel.ClosedXml
         {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
 
-            return new Workbook(new XLWorkbook(stream, XLEventTracking.Disabled));
+            return new Workbook(new XLWorkbook(stream));
         }
     }
 }

--- a/src/LittleBlocks.Excel.Extensions/LittleBlocks.Excel.Extensions.csproj
+++ b/src/LittleBlocks.Excel.Extensions/LittleBlocks.Excel.Extensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Authors>Justin French / Aurimas Gecas</Authors>
         <Company>ICG</Company>
@@ -8,7 +8,7 @@
         <RepositoryUrl>https://github.com/LittleBlocks/LittleBlocks.Excel</RepositoryUrl>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\LittleBlocks.Excel.ClosedXml\LittleBlocks.Excel.ClosedXml.csproj" />

--- a/src/LittleBlocks.Excel.SampleApp/LittleBlocks.Excel.SampleApp.csproj
+++ b/src/LittleBlocks.Excel.SampleApp/LittleBlocks.Excel.SampleApp.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
       <ProjectReference Include="..\LittleBlocks.Excel.ClosedXml\LittleBlocks.Excel.ClosedXml.csproj" />

--- a/src/LittleBlocks.Excel.SampleApp/Program.cs
+++ b/src/LittleBlocks.Excel.SampleApp/Program.cs
@@ -67,7 +67,7 @@ namespace LittleBlocks.Excel.SampleApp
         private static IWorkbook LoadWorkbook(string dataFile)
         {
             var datafilePath = $"{AppDomain.CurrentDomain.BaseDirectory}\\data\\{dataFile}";
-            var workbook = new XLWorkbook(GetMemoryStream(datafilePath), XLEventTracking.Disabled);
+            var workbook = new XLWorkbook(GetMemoryStream(datafilePath));
             var fileName = Path.GetFileName(datafilePath);
             return new Workbook(workbook, fileName);
         }

--- a/src/LittleBlocks.Excel.UnitTests/LittleBlocks.Excel.UnitTests.csproj
+++ b/src/LittleBlocks.Excel.UnitTests/LittleBlocks.Excel.UnitTests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="LittleBlocks.Testing" Version="1.0.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="LittleBlocks.Testing" Version="2.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="xunit" Version="2.7.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/LittleBlocks.Excel/LittleBlocks.Excel.csproj
+++ b/src/LittleBlocks.Excel/LittleBlocks.Excel.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Authors>Mohammad Moattar, Justin French, Aurimas Gecas</Authors>
         <Company>ICG</Company>
         <Description>Abstraction &amp; Fluent API for loading and manipulating excel OpenDocument format.</Description>
@@ -8,7 +8,7 @@
         <RepositoryUrl>https://github.com/LittleBlocks/LittleBlocks.Excel</RepositoryUrl>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="LittleBlocks.Extensions" Version="1.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
+        <PackageReference Include="LittleBlocks.Extensions" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
upgrade to dotnet 8


Im also upgrading LittleBlocks.Reports - it requries this package so will put that our for PR once we merge and publish this latest version

FYI - ClosedXML migration was followed for the below: 
![image](https://github.com/LittleBlocks/LittleBlocks.Excel/assets/33624714/14c45cb6-b805-487f-a648-8513df754f61)
